### PR TITLE
Link farmOS in README acknowledgements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integr
 
 ### Acknowledgements ###
 
-FarmData2 is powered by the farmOS open source project.
+FarmData2 is powered by the [farmOS](https://github.com/NSCC-ITC-Winter2026-WEBD3030-700-MCa/GitKit-FarmData2.git) open source project.
 
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 


### PR DESCRIPTION
Change the plain text farmOS to a hyperlink in the Acknowledgements section of README.md.

__Pull Request Description__

Changes "farmOS" in the Acknowledgements section of README.md into a link to the official website.

Closes #39  

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
